### PR TITLE
Develop

### DIFF
--- a/AutoEquatable.playground/Sources/AutoEquatable.swift
+++ b/AutoEquatable.playground/Sources/AutoEquatable.swift
@@ -25,7 +25,7 @@ public protocol AutoEquatableEnum: Equatable, AutoEquatableGeneric {
     static func areAssociatedValuesEqual(_ lhs: Any, _ rhs: Any) -> Bool
 }
 
-extension AutoEquatableEnum where Self: Equatable {
+extension AutoEquatableEnum {
     public static func areAssociatedValuesEqual(_ lhs: Any, _ rhs: Any) -> Bool {
         if let lhs = lhs as? _InternalAutoEquatable, let rhs = rhs as? _InternalAutoEquatable {
             return lhs._isEqual(to: rhs)
@@ -150,7 +150,7 @@ private func isAFunction(value: Any) -> Bool {
 private func typeNameWithOutGenerics<T>(_: T.Type) -> String {
     let type = String(describing: T.self)
 
-    if let typeWithoutGeneric = type.characters.split(separator: "<").first {
+    if let typeWithoutGeneric = type.split(separator: "<").first {
         return String(typeWithoutGeneric)
     }
 

--- a/AutoEquatable.playground/Sources/AutoEquatable.swift
+++ b/AutoEquatable.playground/Sources/AutoEquatable.swift
@@ -163,4 +163,5 @@ extension String: AutoEquatable {}
 extension Int: AutoEquatable {}
 extension Double: AutoEquatable {}
 extension Float: AutoEquatable {}
+extension Bool: AutoEquatable {}
 extension Set: AutoEquatable {}


### PR DESCRIPTION
- fixed two warnings related to the modern swift syntax
- added Bool as AutoEquatable type by default