### PR TITLE
Return false whenever collections being compared have different counts

### DIFF
--- a/AutoEquatable.playground/Contents.swift
+++ b/AutoEquatable.playground/Contents.swift
@@ -315,6 +315,15 @@ describe("AutoEquatable") {
                 expect(myClassWithArray1 == myClassWithArray2).to(beFalse())
             }
         }
+
+        context("when the arrays have different count") {
+            it("should return false") {
+                let myClassWithArray1 = MyClassWithArray(myArray: [(-1, -1), (-2, -2)])
+                let myClassWithArray2 = MyClassWithArray(myArray: [(-1, -1)])
+                
+                expect(myClassWithArray1 == myClassWithArray2).to(beFalse())
+            }
+        }
     }
 
     describe("properties that are dictionaries") {
@@ -331,6 +340,15 @@ describe("AutoEquatable") {
             it("should return false") {
                 let myClassWithDictionary1 = MyClassWithDictionary(myDictionary: ["one": "1", "two": "2"])
                 let myClassWithDictionary2 = MyClassWithDictionary(myDictionary: ["one": "1", "three": "3"])
+                
+                expect(myClassWithDictionary1 == myClassWithDictionary2).to(beFalse())
+            }
+        }
+        
+        context("when the dictionaries have different counts") {
+            it("should return false") {
+                let myClassWithDictionary1 = MyClassWithDictionary(myDictionary: ["one": "1", "two": "2"])
+                let myClassWithDictionary2 = MyClassWithDictionary(myDictionary: ["one": "1"])
 
                 expect(myClassWithDictionary1 == myClassWithDictionary2).to(beFalse())
             }

--- a/AutoEquatable.playground/Sources/AutoEquatable.swift
+++ b/AutoEquatable.playground/Sources/AutoEquatable.swift
@@ -75,16 +75,23 @@ extension AutoEquatable where Self: Collection {
 // MARK: - Private Helpers
 
 private func areChildrenEqual(lhsMirror: Mirror, rhsMirror: Mirror) -> Bool {
-    let lhsProperties = lhsMirror.children.map { $0.1 }
-    let rhsProperties = rhsMirror.children.map { $0.1 }
-
-    for (lhsProperty, rhsProperty) in zip(lhsProperties, rhsProperties) {
-        if !isPropertyEqual(lhsProperty: lhsProperty, rhsProperty: rhsProperty) {
-            return false
+    let lhsChildren = lhsMirror.children
+    let rhsChildren = rhsMirror.children
+    
+    if (lhsChildren.count == rhsChildren.count) {
+        let lhsProperties = lhsMirror.children.map { $0.1 }
+        let rhsProperties = rhsMirror.children.map { $0.1 }
+        
+        for (lhsProperty, rhsProperty) in zip(lhsProperties, rhsProperties) {
+            if !isPropertyEqual(lhsProperty: lhsProperty, rhsProperty: rhsProperty) {
+                return false
+            }
         }
+        
+        return true
+    } else {
+        return false
     }
-
-    return true
 }
 
 private func isPropertyEqual(lhsProperty: Any, rhsProperty: Any) -> Bool {


### PR DESCRIPTION
When comparing collections or dictionaries that have different counts, the AutoEquatable operator returns true due to only comparing those children included in the `zip()` call, which will always be the first `min(lhsProperties.count, rhsProperties.count)` pairs of elements. This pull request includes a fix for this.