### PR TITLE
Compare enum associated values using respective Equality method

### DIFF
--- a/AutoEquatable.playground/Contents.swift
+++ b/AutoEquatable.playground/Contents.swift
@@ -95,6 +95,11 @@ enum EnumWithAssociatedValue: AutoEquatable {
     case dos(String, Int)
 }
 
+enum EnumWithEnumAssociatedValue: AutoEquatable {
+    case one
+    case two(EnumWithAssociatedValue)
+}
+
 class MyClassWithEnumWithAssociatedValue: AutoEquatable {
     let myEnum: EnumWithAssociatedValue
 
@@ -436,6 +441,35 @@ describe("AutoEquatable") {
                     let myEnum1 = EnumWithAssociatedValue.uno("")
                     let myEnum2 = EnumWithAssociatedValue.dos("", 0)
 
+                    expect(myEnum1 == myEnum2).to(beFalse())
+                }
+            }
+        }
+        
+        describe("enums with enum associated values") {
+            context("when the case w/o associated values are the same") {
+                it("should return true when using convienence function") {
+                    let myEnum1 = EnumWithEnumAssociatedValue.one
+                    let myEnum2 = EnumWithEnumAssociatedValue.one
+                    
+                    expect(myEnum1 == myEnum2).to(beTrue())
+                }
+            }
+            
+            context("when the associated values are the same") {
+                it("should return true when using convienence function") {
+                    let myEnum1 = EnumWithEnumAssociatedValue.two(.uno("String"))
+                    let myEnum2 = EnumWithEnumAssociatedValue.two(.uno("String"))
+                    
+                    expect(myEnum1 == myEnum2).to(beTrue())
+                }
+            }
+
+            context("when the associated values are not the same") {
+                it("should return true when using convienence function") {
+                    let myEnum1 = EnumWithEnumAssociatedValue.two(.uno("String1"))
+                    let myEnum2 = EnumWithEnumAssociatedValue.two(.uno("String2"))
+                    
                     expect(myEnum1 == myEnum2).to(beFalse())
                 }
             }

--- a/AutoEquatable.playground/Sources/AutoEquatable.swift
+++ b/AutoEquatable.playground/Sources/AutoEquatable.swift
@@ -31,7 +31,7 @@ extension AutoEquatable {
 
         if lhsMirror.displayStyle == .enum {
             // The case names should be the same
-            guard enumName(lhs) == enumName(rhs) else {
+            guard enumCaseName(lhs) == enumCaseName(rhs) else {
                 return false
             }
             // All associated values should be equal
@@ -47,7 +47,7 @@ extension AutoEquatable {
     }
 }
 
-private func enumName(_ value: Any) -> String {
+private func enumCaseName(_ value: Any) -> String {
     let name = String(describing: value)
     if let index = name.range(of: "(")?.lowerBound {
         return String(name.prefix(upTo: index))


### PR DESCRIPTION
This removes the logic, which fails on some machines, to compare associated values as the raw bytes represented by an `enum` `case`. This resolves two issues we experienced in our project:
1. Some `case`s, without associated values, would be equal even if the `case` names were different
2. Some equality tests for `case`s, when they had associated values, would fail on some machines and succeed on others. I haven't been able to pin-point the exact cause.

All tests pass.